### PR TITLE
Correctly report solver CPU runtimes.

### DIFF
--- a/src/Changelog
+++ b/src/Changelog
@@ -1,5 +1,6 @@
 Changes after version 3.4.0
 
+- Maximize over measured solver CPU times to account for nondeterministic measurement errors (Jendrik Seipp).
 - Compile without libnuma (Jendrik Seipp).
 - Let compiler choose bitwidth (Jendrik Seipp).
 - Remove SVN version number (Jendrik Seipp).


### PR DESCRIPTION
Silvan stumbled over a bug in runsolver:

```
I had a look at GBFS with FF on depot 5. You can find all relevant files at /infai/sieverss/repos/downward/new-benchmarks/experiments/data/2021-09-05-B-evaluation-sat-2021-09-05/runs-00101-00200/00185

runsolver writes the "outcome" of the solver run to values.log:

# WCTIME: wall clock time in seconds
WCTIME=1897.78
# CPUTIME: CPU time in seconds (USERTIME+SYSTEMTIME)
CPUTIME=3.71924
# USERTIME: CPU time spent in user mode in seconds
USERTIME=3.39931
# SYSTEMTIME: CPU time spent in system mode in seconds
SYSTEMTIME=0.319926
# CPUUSAGE: CPUTIME/WCTIME in percent
CPUUSAGE=0.195979
# MAXVM: maximum virtual memory used in KiB
MAXVM=968524
# MAXMM: maximum memory used in KiB
MAXMM=204932
# MAXRSS: maximum Resident Segment Size in KiB
MAXRSS=107944
# TIMEOUT: did the solver exceed the time limit?
TIMEOUT=false
# MEMOUT: did the solver exceed the memory limit?
MEMOUT=false
# EXITSTATUS: Exit status of the solver
EXITSTATUS=36608

From there, I just parse TIMEOUT and MEMOUT for out_of_time and out_of_memory. I also parse CPUTIME for runtime.

However, TIMEOUT doesn't seem to be what we think it should be. In this case, runsolver thinks that the solver did *not* run out of time, although I think it did, looking at WCTIME. I also ran the image locally and got the same "last f line" output as in run.log (i.e., output of the run on the grid):

[...]
New best heuristic value for ff: 6
[g=32, 3558 evaluated, 134 expanded, t=1.99187s, 35988 KB]


I waited ~10 minutes but nothing happened, so I assume that after 1800s, runsolver "starts" to terminate the planner (first soft limit, then hard limit).

What I don't understand, though, is why CPUTIME (in values.log) is that low. Looking at watch.log, the output there seems a bit contradictory to me:

======
Current children cumulated CPU time: 1800.05 s
Current children cumulated vsize: 968524 KiB
Current children cumulated memory: 204932 KiB

Child status: 143
Real time (s): 1897.78

[solver*Times]
    CPU time (s): 3.71924
    CPU user time (s): 3.39931
    CPU system time (s): 0.319926
    CPU usage (%): 0.195979

Max. virtual memory (cumulated for all children) (KiB): 968524
Max. memory (cumulated for all children) (KiB): 204932

getrusage(RUSAGE_CHILDREN,...) data:
user time used= 3.39931
system time used= 0.319926
maximum resident set size= 107944
integral shared memory size= 0
integral unshared data size= 0
integral unshared stack size= 0
page reclaims= 60747
page faults= 35
swaps= 0
block input operations= 9116
block output operations= 2872
messages sent= 0
messages received= 0
signals received= 0
voluntary context switches= 1615
involuntary context switches= 1956


# summary of solver processes directly reported to runsolver:
#   pid: 109942,109944
#   total CPU time (s): 3.71924
#   total CPU user time (s): 3.39931
#   total CPU system time (s): 0.319926

??? end of timestamper thread
runsolver used 23.6122 second user time and 67.8529 second system time
======

So runsolver kills the solver very precisely when it uses "acumulated CPU time" of 1800s, but that time usage doesn't figure in the CPU time output. 
```

My proposed solution:

Previously, the solver\*Time values () were computed with
getrusage(RUSAGE_CHILDREN, ...). This function call returns resource usage
statistics for all descendants of the calling process (i.e., the solver
process and its descendants) that have terminated and have been waited
for. This means that subprocesses that have not called wait() are ignored.
Since this often underestimates the CPU times, we instead recompute the
CPU time for the watched process (current\*Time) and add the time for
children that have already terminated (completed*Time).